### PR TITLE
Fix example line in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Install the package and include `setuptools_version` in your tox.ini
 
 ```tox
 [testenv]
-setuptools_version = setuptools_version<58
+setuptools_version = setuptools<58
 ```
 
 Or, set the `TOX_SETUPTOOLS_VERSION` environment variable,


### PR DESCRIPTION
the line `setuptools_version = setuptools_version<58` breaks with
```
ERROR: No matching distribution found for setuptools_version<60
```
by which I inferred that I probably wanted `setuptools<60` :)